### PR TITLE
Do not hardcode Host header in requests.

### DIFF
--- a/lib/sync_package.js
+++ b/lib/sync_package.js
@@ -8,7 +8,6 @@ var options = {};
 var cache = {};
 
 var HEADERS = {
-  Host: 'isaacs.iriscouch.com',
   accept: 'multipart/related,application/json'
 };
 


### PR DESCRIPTION
I realize this header was added some time ago, but this prevents sync_package from working with any remote registry other than isaacs.iriscouch.com (ex: https://fullfatdb.npmjs.com/registry/ ).
