### PR TITLE
Introduced dependency on 'npm-fullfat-registry'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+# IntelliJ IDEA leftovers
+.idea

--- a/bin/sync_package
+++ b/bin/sync_package
@@ -1,19 +1,20 @@
 #!/usr/bin/env node
-var sync = require("../lib/sync_package");
-
+var sync = require('../lib/sync_package');
 var program = require('commander');
+
 program
   .version(require('../package.json').version)
-  .option('-D, --no-denpendencies', 'Dont sync denpendencies')
-  .option('-a, --devdenpendencies', 'Sync all dev denpendencies')
+  .option('-D, --no-dependencies', 'Dont sync dependencies')
+  .option('-a, --devdependencies', 'Sync all dev dependencies')
   .option('-b, --browser', 'use browser mode color')
+  .option('-t, --tempdir [tempdir]', 'temporary folder used for dependencies storage [/tmp]', '/tmp')
   .parse(process.argv);
 
 if (program.args.length < 1) {
-  console.log("Syntax: sync_package packagename [-D][-a]");
-  return;
+  program.outputHelp();
+  process.exit(1);
 }
 
 program.args.forEach(function (id) {
-  sync(id, program.denpendencies, program.devdenpendencies, program.browser);
+  sync(id, program.dependencies, program.devdependencies, program.browser, program.tempdir);
 });

--- a/lib/sync_package.js
+++ b/lib/sync_package.js
@@ -4,188 +4,186 @@ var npm = require('npm');
 var colors = require('colors');
 
 var options = {};
-
 var cache = {};
-
 var HEADERS = {
-    accept: 'multipart/related,application/json'
+  accept: 'multipart/related,application/json'
 };
 
 var compare = function (id, installDependencies, installDevDependencies, callback) {
-    var ep = new EventProxy();
-    ep.all('from', 'to', function (from, to) {
-        callback(null, from, to);
-    });
-    ep.fail(callback);
-    request.get({
-        url: options.from + encodeURIComponent(id) + '?revs_info=true',
-        headers: HEADERS
-    }, ep.done('from', function (res, body) {
-        var doc;
-        try {
-            doc = JSON.parse(body);
-        } catch (err) {
-            err.message = 'Parse `from` module body error: ' + err.message;
-            return ep.emit('error', err);
-        }
-        if (doc.error) {
-            return '';
-        }
+  var ep = new EventProxy();
+  ep.all('from', 'to', function (from, to) {
+    callback(null, from, to);
+  });
+  ep.fail(callback);
+  request.get({
+    url: options.from + encodeURIComponent(id) + '?revs_info=true',
+    headers: HEADERS
+  }, ep.done('from', function (res, body) {
+    var doc;
+    try {
+      doc = JSON.parse(body);
+    } catch (err) {
+      err.message = 'Parse `from` module body error: ' + err.message;
+      return ep.emit('error', err);
+    }
+    if (doc.error) {
+      return '';
+    }
 
-        var latest = doc['dist-tags']['latest'];
-        var dependencies = Object.keys(doc.versions[latest].dependencies || {});
-        var devDependencies = Object.keys(doc.versions[latest].devDependencies || {});
-        var allDependencies = installDevDependencies ? dependencies.concat(devDependencies) : dependencies;
-        if (installDependencies && allDependencies.length > 0) {
-            console.log('Check ' + id.magenta + '\'s ' + ('' + allDependencies.length).magenta + ' dependencies');
-            allDependencies.forEach(function (dependency) {
-                console.log('Sync dependency ' + dependency.underline.cyan);
-                sync(dependency, installDependencies);
-            });
-        }
-        return doc._rev;
-    }));
+    var latest = doc['dist-tags']['latest'];
+    var dependencies = Object.keys(doc.versions[latest].dependencies || {});
+    var devDependencies = Object.keys(doc.versions[latest].devDependencies || {});
+    var allDependencies = installDevDependencies ? dependencies.concat(devDependencies) : dependencies;
+    if (installDependencies && allDependencies.length > 0) {
+      console.log('Check ' + id.magenta + '\'s ' + ('' + allDependencies.length).magenta + ' dependencies');
+      allDependencies.forEach(function (dependency) {
+        console.log('Sync dependency ' + dependency.underline.cyan);
+        sync(dependency, installDependencies);
+      });
+    }
+    return doc._rev;
+  }));
 
-    request.get({
-        url: options.to + encodeURIComponent(id) + '?revs_info=true'
-    }, ep.done('to', function (res, body) {
-        var doc;
-        try {
-            doc = JSON.parse(body);
-        } catch (err) {
-            err.message = 'Parse `to` module body error: ' + err.message;
-            return ep.emit('error', err);
-        }
-        if (doc.error) {
-            return '';
-        }
+  request.get({
+    url: options.to + encodeURIComponent(id) + '?revs_info=true'
+  }, ep.done('to', function (res, body) {
+    var doc;
+    try {
+      doc = JSON.parse(body);
+    } catch (err) {
+      err.message = 'Parse `to` module body error: ' + err.message;
+      return ep.emit('error', err);
+    }
+    if (doc.error) {
+      return '';
+    }
 
-        return doc._rev;
-    }));
+    return doc._rev;
+  }));
 };
 
 
 function fetchDependencies(id, rev, tempDir, cb) {
-    console.log("Syncing %s rev=%s", id.magenta, rev.magenta);
+  console.log("Syncing %s rev=%s", id.magenta, rev.magenta);
 
-    var FF = require('npm-fullfat-registry');
-    var execute = new FF({
-        skim: options.from,
-        fat: options.to,
-        tmp: tempDir
+  var FF = require('npm-fullfat-registry');
+  var execute = new FF({
+    skim: options.from,
+    fat: options.to,
+    tmp: tempDir
+  });
+
+  request({
+      url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
+      headers: HEADERS
+    },
+    function (error, response, body) {
+      if (error) {
+        console.error("Error fetching document", error, body);
+        return cb(err);
+      }
+
+      execute.on('error', function(err) {
+        execute.destroy();
+        cb(err);
+      });
+      execute.on('put', function(doc, response) {
+        execute.destroy();
+        cb(null, response);
+      });
+
+      execute.onchange(null, {id: id, doc: JSON.parse(body)});
     });
-
-    request({
-            url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
-            headers: HEADERS
-        },
-        function (error, response, body) {
-            if (error) {
-                console.error("Error fetching document", error, body);
-                return cb(err);
-            }
-
-            execute.on('error', function(err) {
-                execute.destroy();
-                cb(err);
-            });
-            execute.on('put', function(doc, response) {
-                execute.destroy();
-                cb(null, response);
-            });
-
-            execute.onchange(null, {id: id, doc: JSON.parse(body)});
-        });
 }
 
 var _sync = function (id, rev, callback) {
-    callback = callback || function () {};
+  callback = callback || function () {};
 
-    request.get({
-        url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
-        headers: HEADERS
-    }).pipe(request.put(options.to + encodeURIComponent(id) + '?new_edits=false&rev=' + rev, function (e, resp, b) {
-        if (e) {
-            callback(e, {id: id, rev: rev, body: b});
-        } else if (resp.statusCode > 199 && resp.statusCode < 300) {
-            callback(null, {id: id, rev: rev, success: true, resp: resp, body: b});
-        } else {
-            callback(new Error('status code is not 201. statusCode: ' + resp.statusCode), {id: id, resp: resp, body: b});
-        }
-    })).on('data', function () {
-        console.log('...'.green);
-    });
+  request.get({
+    url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
+    headers: HEADERS
+  }).pipe(request.put(options.to + encodeURIComponent(id) + '?new_edits=false&rev=' + rev, function (e, resp, b) {
+    if (e) {
+      callback(e, {id: id, rev: rev, body: b});
+    } else if (resp.statusCode > 199 && resp.statusCode < 300) {
+      callback(null, {id: id, rev: rev, success: true, resp: resp, body: b});
+    } else {
+      callback(new Error('status code is not 201. statusCode: ' + resp.statusCode), {id: id, resp: resp, body: b});
+    }
+  })).on('data', function () {
+    console.log('...'.green);
+  });
 };
 
 var sync = function (id, installDependencies, installDevDependencies, browser, tempDir, callback) {
-    if (typeof browser === 'function') {
-        callback = browser;
-        browser = false;
+  if (typeof browser === 'function') {
+    callback = browser;
+    browser = false;
+  }
+  if (browser) {
+    colors.mode = 'browser';
+  }
+  if (cache[id]) {
+    return;
+  } else {
+    cache[id] = true;
+  }
+  callback = callback || function () {
+    console.log(('Sync ' + id + ' done.').green);
+  };
+
+  npm.load('~/.npmrc', function (err) {
+    if (err) {
+      throw err;
     }
-    if (browser) {
-        colors.mode = 'browser';
+    options.from = npm.config.get('remote_registry') || 'http://isaacs.iriscouch.com/registry/';
+    options.to = npm.config.get('local_registry');
+    if (!options.from || !options.to) {
+      console.log('Please use ');
+      console.log('\tnpm config set remote_registry {remote_registry}'.yellow);
+      console.log('\tnpm config set local_registry {local_registry}');
+      console.log('to set the remote and local registry.');
+      return;
     }
-    if (cache[id]) {
-        return;
-    } else {
-        cache[id] = true;
-    }
-    callback = callback || function () {
-        console.log(('Sync ' + id + ' done.').green);
-    };
 
-    npm.load('~/.npmrc', function (err) {
-        if (err) {
-            throw err;
-        }
-        options.from = npm.config.get('remote_registry') || 'http://isaacs.iriscouch.com/registry/';
-        options.to = npm.config.get('local_registry');
-        if (!options.from || !options.to) {
-            console.log('Please use ');
-            console.log('\tnpm config set remote_registry {remote_registry}'.yellow);
-            console.log('\tnpm config set local_registry {local_registry}');
-            console.log('to set the remote and local registry.');
-            return;
-        }
+    console.log('Sync package ' + id.magenta + ' from ' + options.from + ' to ' + options.to.replace(/\/\/(.*@)/, '//'));
+    compare(id, installDependencies, installDevDependencies, function (err, from, to) {
+      if (err) {
+        err.message = '. Wait a minute and try again!';
+        throw err;
+      }
 
-        console.log('Sync package ' + id.magenta + ' from ' + options.from + ' to ' + options.to.replace(/\/\/(.*@)/, '//'));
-        compare(id, installDependencies, installDevDependencies, function (err, from, to) {
-            if (err) {
-                err.message = '. Wait a minute and try again!';
-                throw err;
-            }
+      if (!from) {
+        console.log('The remote package is inexsit, no need sync.');
+        return callback();
+      }
 
-            if (!from) {
-                console.log('The remote package is inexsit, no need sync.');
-                return callback();
-            }
+      if (from !== to) {
+        console.log('The revision of remote package ' + id.magenta + ' is ' + from);
+        console.log('The revision of local package ' + id.magenta + ' is ' + to);
 
-            if (from !== to) {
-                console.log('The revision of remote package ' + id.magenta + ' is ' + from);
-                console.log('The revision of local package ' + id.magenta + ' is ' + to);
-
-                _sync(id, from, function (err, result) {
-                    console.log(result.body);
-                    if (err) {
-                        console.warn(err.message);
-                        console.warn(result.body);
-                        console.log(('Sync ' + id + ', rev: ' + from + ' fail.').red);
-                    } else {
-                        fetchDependencies(id, from, tempDir, function (err, result) {
-                            if (err) {
-                                console.log(('Sync ' + id + ', rev: ' + from + ' failed.').red, err);
-                            } else {
-                                console.log(('Sync ' + id + ', rev: ' + from + ' done.').green);
-                            }
-                        });
-                    }
-                });
-            } else {
-                console.log('The local ' + id.green + ' package is same as remote package, no need sync again.');
-                callback();
-            }
+        _sync(id, from, function (err, result) {
+          console.log(result.body);
+          if (err) {
+            console.warn(err.message);
+            console.warn(result.body);
+            console.log(('Sync ' + id + ', rev: ' + from + ' fail.').red);
+          } else {
+            fetchDependencies(id, from, tempDir, function (err, result) {
+              if (err) {
+                console.log(('Sync ' + id + ', rev: ' + from + ' failed.').red, err);
+              } else {
+                console.log(('Sync ' + id + ', rev: ' + from + ' done.').green);
+              }
+            });
+          }
         });
+      } else {
+        console.log('The local ' + id.green + ' package is same as remote package, no need sync again.');
+        callback();
+      }
     });
+  });
 };
 
 module.exports = sync;

--- a/lib/sync_package.js
+++ b/lib/sync_package.js
@@ -82,7 +82,7 @@ function fetchDependencies(id, rev, tempDir, cb) {
         function (error, response, body) {
             if (error) {
                 console.error("Error fetching document", error, body);
-                process.exit(1);
+                return cb(err);
             }
 
             execute.on('error', function(err) {

--- a/lib/sync_package.js
+++ b/lib/sync_package.js
@@ -86,6 +86,7 @@ function fullfatdo (id, rev, tempDir, cb) {
         }
 
         execute.on('error', function(err) {
+            execute.destroy();
             cb(err);
         });
         execute.on('put', function(doc, response) {

--- a/lib/sync_package.js
+++ b/lib/sync_package.js
@@ -8,66 +8,66 @@ var options = {};
 var cache = {};
 
 var HEADERS = {
-  accept: 'multipart/related,application/json'
+    accept: 'multipart/related,application/json'
 };
 
 var compare = function (id, installDependencies, installDevDependencies, callback) {
-  var ep = new EventProxy();
-  ep.all('from', 'to', function (from, to) {
-    callback(null, from, to);
-  });
-  ep.fail(callback);
-  request.get({
-    url: options.from + encodeURIComponent(id) + '?revs_info=true',
-    headers: HEADERS
-  }, ep.done('from', function (res, body) {
-    var doc;
-    try {
-      doc = JSON.parse(body);
-    } catch (err) {
-      err.message = 'Parse `from` module body error: ' + err.message;
-      return ep.emit('error', err);
-    }
-    if (doc.error) {
-      return '';
-    }
+    var ep = new EventProxy();
+    ep.all('from', 'to', function (from, to) {
+        callback(null, from, to);
+    });
+    ep.fail(callback);
+    request.get({
+        url: options.from + encodeURIComponent(id) + '?revs_info=true',
+        headers: HEADERS
+    }, ep.done('from', function (res, body) {
+        var doc;
+        try {
+            doc = JSON.parse(body);
+        } catch (err) {
+            err.message = 'Parse `from` module body error: ' + err.message;
+            return ep.emit('error', err);
+        }
+        if (doc.error) {
+            return '';
+        }
 
-    var latest = doc['dist-tags']['latest'];
-    var dependencies = Object.keys(doc.versions[latest].dependencies || {});
-    var devDependencies = Object.keys(doc.versions[latest].devDependencies || {});
-    var allDependencies = installDevDependencies ? dependencies.concat(devDependencies) : dependencies;
-    if (installDependencies && allDependencies.length > 0) {
-      console.log('Check ' + id.magenta + '\'s ' + ('' + allDependencies.length).magenta + ' dependencies');
-      allDependencies.forEach(function (dependency) {
-        console.log('Sync dependency ' + dependency.underline.cyan);
-        sync(dependency, installDependencies);
-      });
-    }
-    return doc._rev;
-  }));
+        var latest = doc['dist-tags']['latest'];
+        var dependencies = Object.keys(doc.versions[latest].dependencies || {});
+        var devDependencies = Object.keys(doc.versions[latest].devDependencies || {});
+        var allDependencies = installDevDependencies ? dependencies.concat(devDependencies) : dependencies;
+        if (installDependencies && allDependencies.length > 0) {
+            console.log('Check ' + id.magenta + '\'s ' + ('' + allDependencies.length).magenta + ' dependencies');
+            allDependencies.forEach(function (dependency) {
+                console.log('Sync dependency ' + dependency.underline.cyan);
+                sync(dependency, installDependencies);
+            });
+        }
+        return doc._rev;
+    }));
 
-  request.get({
-    url: options.to + encodeURIComponent(id) + '?revs_info=true'
-  }, ep.done('to', function (res, body) {
-    var doc;
-    try {
-      doc = JSON.parse(body);
-    } catch (err) {
-      err.message = 'Parse `to` module body error: ' + err.message;
-      return ep.emit('error', err);
-    }
-    if (doc.error) {
-      return '';
-    }
+    request.get({
+        url: options.to + encodeURIComponent(id) + '?revs_info=true'
+    }, ep.done('to', function (res, body) {
+        var doc;
+        try {
+            doc = JSON.parse(body);
+        } catch (err) {
+            err.message = 'Parse `to` module body error: ' + err.message;
+            return ep.emit('error', err);
+        }
+        if (doc.error) {
+            return '';
+        }
 
-    return doc._rev;
-  }));
+        return doc._rev;
+    }));
 };
 
 
-function fullfatdo (id, rev, tempDir, cb) {
+function fetchDependencies(id, rev, tempDir, cb) {
     console.log("Syncing %s rev=%s", id.magenta, rev.magenta);
-    
+
     var FF = require('npm-fullfat-registry');
     var execute = new FF({
         skim: options.from,
@@ -76,116 +76,116 @@ function fullfatdo (id, rev, tempDir, cb) {
     });
 
     request({
-        url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
-        headers: HEADERS
-    },
-    function (error, response, body) {
-        if (error) {
-            console.error("Error fetching document", error, body);
-            process.exit(1);
-        }
+            url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
+            headers: HEADERS
+        },
+        function (error, response, body) {
+            if (error) {
+                console.error("Error fetching document", error, body);
+                process.exit(1);
+            }
 
-        execute.on('error', function(err) {
-            execute.destroy();
-            cb(err);
-        });
-        execute.on('put', function(doc, response) {
-            execute.destroy();
-            cb(null, response);
-        });
+            execute.on('error', function(err) {
+                execute.destroy();
+                cb(err);
+            });
+            execute.on('put', function(doc, response) {
+                execute.destroy();
+                cb(null, response);
+            });
 
-        execute.onchange(null, {id: id, doc: JSON.parse(body)});
-    });
+            execute.onchange(null, {id: id, doc: JSON.parse(body)});
+        });
 }
 
 var _sync = function (id, rev, callback) {
-  callback = callback || function () {};
+    callback = callback || function () {};
 
-  request.get({
-    url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
-    headers: HEADERS
-  }).pipe(request.put(options.to + encodeURIComponent(id) + '?new_edits=false&rev=' + rev, function (e, resp, b) {
-    if (e) {
-      callback(e, {id: id, rev: rev, body: b});
-    } else if (resp.statusCode > 199 && resp.statusCode < 300) {
-      callback(null, {id: id, rev: rev, success: true, resp: resp, body: b});
-    } else {
-      callback(new Error('status code is not 201. statusCode: ' + resp.statusCode), {id: id, resp: resp, body: b});
-    }
-  })).on('data', function () {
-    console.log('...'.green);
-  });
+    request.get({
+        url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
+        headers: HEADERS
+    }).pipe(request.put(options.to + encodeURIComponent(id) + '?new_edits=false&rev=' + rev, function (e, resp, b) {
+        if (e) {
+            callback(e, {id: id, rev: rev, body: b});
+        } else if (resp.statusCode > 199 && resp.statusCode < 300) {
+            callback(null, {id: id, rev: rev, success: true, resp: resp, body: b});
+        } else {
+            callback(new Error('status code is not 201. statusCode: ' + resp.statusCode), {id: id, resp: resp, body: b});
+        }
+    })).on('data', function () {
+        console.log('...'.green);
+    });
 };
 
 var sync = function (id, installDependencies, installDevDependencies, browser, tempDir, callback) {
-  if (typeof browser === 'function') {
-    callback = browser;
-    browser = false;
-  }
-  if (browser) {
-    colors.mode = 'browser';
-  }
-  if (cache[id]) {
-    return;
-  } else {
-    cache[id] = true;
-  }
-  callback = callback || function () {
-    console.log(('Sync ' + id + ' done.').green);
-  };
-
-  npm.load('~/.npmrc', function (err) {
-    if (err) {
-      throw err;
+    if (typeof browser === 'function') {
+        callback = browser;
+        browser = false;
     }
-    options.from = npm.config.get('remote_registry') || 'http://isaacs.iriscouch.com/registry/';
-    options.to = npm.config.get('local_registry');
-    if (!options.from || !options.to) {
-      console.log('Please use ');
-      console.log('\tnpm config set remote_registry {remote_registry}'.yellow);
-      console.log('\tnpm config set local_registry {local_registry}');
-      console.log('to set the remote and local registry.');
-      return;
+    if (browser) {
+        colors.mode = 'browser';
     }
+    if (cache[id]) {
+        return;
+    } else {
+        cache[id] = true;
+    }
+    callback = callback || function () {
+        console.log(('Sync ' + id + ' done.').green);
+    };
 
-    console.log('Sync package ' + id.magenta + ' from ' + options.from + ' to ' + options.to.replace(/\/\/(.*@)/, '//'));
-    compare(id, installDependencies, installDevDependencies, function (err, from, to) {
-      if (err) {
-        err.message = '. Wait a minute and try again!';
-        throw err;
-      }
+    npm.load('~/.npmrc', function (err) {
+        if (err) {
+            throw err;
+        }
+        options.from = npm.config.get('remote_registry') || 'http://isaacs.iriscouch.com/registry/';
+        options.to = npm.config.get('local_registry');
+        if (!options.from || !options.to) {
+            console.log('Please use ');
+            console.log('\tnpm config set remote_registry {remote_registry}'.yellow);
+            console.log('\tnpm config set local_registry {local_registry}');
+            console.log('to set the remote and local registry.');
+            return;
+        }
 
-      if (!from) {
-        console.log('The remote package is inexsit, no need sync.');
-        return callback();
-      }
+        console.log('Sync package ' + id.magenta + ' from ' + options.from + ' to ' + options.to.replace(/\/\/(.*@)/, '//'));
+        compare(id, installDependencies, installDevDependencies, function (err, from, to) {
+            if (err) {
+                err.message = '. Wait a minute and try again!';
+                throw err;
+            }
 
-      if (from !== to) {
-        console.log('The revision of remote package ' + id.magenta + ' is ' + from);
-        console.log('The revision of local package ' + id.magenta + ' is ' + to);
+            if (!from) {
+                console.log('The remote package is inexsit, no need sync.');
+                return callback();
+            }
 
-        _sync(id, from, function (err, result) {
-          console.log(result.body);
-          if (err) {
-            console.warn(err.message);
-            console.warn(result.body);
-            console.log(('Sync ' + id + ', rev: ' + from + ' fail.').red);
-          } else {
-            fullfatdo(id, from, tempDir, function (err, result) {
-                if (err) {
-                    console.log(('Sync ' + id + ', rev: ' + from + ' failed.').red, err);
-                } else {
-                    console.log(('Sync ' + id + ', rev: ' + from + ' done.').green); 
-                }
-            });
-          }
+            if (from !== to) {
+                console.log('The revision of remote package ' + id.magenta + ' is ' + from);
+                console.log('The revision of local package ' + id.magenta + ' is ' + to);
+
+                _sync(id, from, function (err, result) {
+                    console.log(result.body);
+                    if (err) {
+                        console.warn(err.message);
+                        console.warn(result.body);
+                        console.log(('Sync ' + id + ', rev: ' + from + ' fail.').red);
+                    } else {
+                        fetchDependencies(id, from, tempDir, function (err, result) {
+                            if (err) {
+                                console.log(('Sync ' + id + ', rev: ' + from + ' failed.').red, err);
+                            } else {
+                                console.log(('Sync ' + id + ', rev: ' + from + ' done.').green);
+                            }
+                        });
+                    }
+                });
+            } else {
+                console.log('The local ' + id.green + ' package is same as remote package, no need sync again.');
+                callback();
+            }
         });
-      } else {
-        console.log('The local ' + id.green + ' package is same as remote package, no need sync again.');
-        callback();
-      }
     });
-  });
 };
 
 module.exports = sync;

--- a/lib/sync_package.js
+++ b/lib/sync_package.js
@@ -64,6 +64,39 @@ var compare = function (id, installDependencies, installDevDependencies, callbac
   }));
 };
 
+
+function fullfatdo (id, rev, tempDir, cb) {
+    console.log("Syncing %s rev=%s", id.magenta, rev.magenta);
+    
+    var FF = require('npm-fullfat-registry');
+    var execute = new FF({
+        skim: options.from,
+        fat: options.to,
+        tmp: tempDir
+    });
+
+    request({
+        url: options.from + encodeURIComponent(id) + '?attachments=true&revs=true&rev=' + rev,
+        headers: HEADERS
+    },
+    function (error, response, body) {
+        if (error) {
+            console.error("Error fetching document", error, body);
+            process.exit(1);
+        }
+
+        execute.on('error', function(err) {
+            cb(err);
+        });
+        execute.on('put', function(doc, response) {
+            execute.destroy();
+            cb(null, response);
+        });
+
+        execute.onchange(null, {id: id, doc: JSON.parse(body)});
+    });
+}
+
 var _sync = function (id, rev, callback) {
   callback = callback || function () {};
 
@@ -83,7 +116,7 @@ var _sync = function (id, rev, callback) {
   });
 };
 
-var sync = function (id, installDependencies, installDevDependencies, browser, callback) {
+var sync = function (id, installDependencies, installDevDependencies, browser, tempDir, callback) {
   if (typeof browser === 'function') {
     callback = browser;
     browser = false;
@@ -99,6 +132,7 @@ var sync = function (id, installDependencies, installDevDependencies, browser, c
   callback = callback || function () {
     console.log(('Sync ' + id + ' done.').green);
   };
+
   npm.load('~/.npmrc', function (err) {
     if (err) {
       throw err;
@@ -112,6 +146,7 @@ var sync = function (id, installDependencies, installDevDependencies, browser, c
       console.log('to set the remote and local registry.');
       return;
     }
+
     console.log('Sync package ' + id.magenta + ' from ' + options.from + ' to ' + options.to.replace(/\/\/(.*@)/, '//'));
     compare(id, installDependencies, installDevDependencies, function (err, from, to) {
       if (err) {
@@ -127,6 +162,7 @@ var sync = function (id, installDependencies, installDevDependencies, browser, c
       if (from !== to) {
         console.log('The revision of remote package ' + id.magenta + ' is ' + from);
         console.log('The revision of local package ' + id.magenta + ' is ' + to);
+
         _sync(id, from, function (err, result) {
           console.log(result.body);
           if (err) {
@@ -134,7 +170,13 @@ var sync = function (id, installDependencies, installDevDependencies, browser, c
             console.warn(result.body);
             console.log(('Sync ' + id + ', rev: ' + from + ' fail.').red);
           } else {
-            console.log(('Sync ' + id + ', rev: ' + from + ' done.').green);
+            fullfatdo(id, from, tempDir, function (err, result) {
+                if (err) {
+                    console.log(('Sync ' + id + ', rev: ' + from + ' failed.').red, err);
+                } else {
+                    console.log(('Sync ' + id + ', rev: ' + from + ' done.').green); 
+                }
+            });
           }
         });
       } else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "eventproxy": "=0.2.5",
     "request": ">=2.10.0",
     "colors": ">=0.6.0-1",
-    "commander": ">=1.0.1"
+    "commander": ">=1.0.1",
+    "npm-fullfat-registry": "1.1.4"
   },
   "bin": "./bin/sync_package",
   "author": "Jackson Tian",


### PR DESCRIPTION
Introduced dependency on 'npm-fullfat-registry' to allow syncing attachments from skim repositories.
Updated .gitignore to prevent IDEA project files to be included in future commits.
## Rationale

because the majority of public facing repositories do not provide the binary attachments it is important to have a mean to also fetch and add them to the `to` repository.

Major thanks to @jvale for help from the beggining
